### PR TITLE
Upgrade Gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 22 21:23:34 WIB 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgrade Gradle to version 8.5 to resolve Java 21 compatibility issues.

The previous Gradle version (8.0.1) did not support Java 21, leading to an `Unsupported class file major version 65` error during the build. Upgrading to Gradle 8.5 provides official support for Java 21, resolving this build failure.